### PR TITLE
Optimizations for extract and format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
  "syn_derive",
 ]
 
@@ -515,6 +515,7 @@ name = "overpunch"
 version = "0.3.0"
 dependencies = [
  "criterion",
+ "memchr",
  "rust_decimal",
  "test-log",
  "thiserror",
@@ -825,7 +826,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -868,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -886,7 +887,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -914,27 +915,27 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "15291287e9bff1bc6f9ff3409ed9af665bec7a5fc8ac079ea96be07bca0e2668"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "22efd00f33f93fa62848a7cab956c3d38c8d43095efda1decfc2b3a5dc0b8972"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1105,7 +1106,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -1127,7 +1128,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1288,5 +1289,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ categories = ["finance", "parsing", "value-formatting"]
 
 [dependencies]
 rust_decimal = "1.36.0"
-thiserror = "1.0.64"
+thiserror = "2.0.0"
+memchr = "2.7.4"
 
 [dev-dependencies]
 test-log = { version = "0.2.16", features = ["trace"] }


### PR DESCRIPTION
Switches to working with bytes (`u8`s), which is slightly more efficient than `chars` due to variable length char-codes of utf8 not having to be supported/validated. Also uses `simd` via `memchr` for byte searching and removes an allocation in `format` by handing over control of the `Vec<u8>` parts directly to the `String`.
```
cargo bench
   Compiling overpunch v0.3.0 (/Users/josephmoniz/src/overpunch)
    Finished `bench` profile [optimized] target(s) in 0.88s
     Running unittests src/lib.rs (target/release/deps/overpunch-244dc83774a84c8a)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running benches/benchmark.rs (target/release/deps/benchmark-c33f02f3f256d33c)
Gnuplot not found, using plotters backend
convert_from_signed_format
                        time:   [12.155 ns 12.252 ns 12.353 ns]
                        change: [-15.112% -14.264% -13.374%] (p = 0.00 < 0.05)
                        Performance has improved.

convert_to_signed_format
                        time:   [30.219 ns 30.256 ns 30.298 ns]
                        change: [-43.997% -43.654% -43.333%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  8 (8.00%) high mild
  4 (4.00%) high severe

extract                 time:   [8.0216 ns 8.0296 ns 8.0390 ns]
                        change: [-18.286% -17.977% -17.666%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe

format                  time:   [28.737 ns 29.002 ns 29.279 ns]
                        change: [-44.112% -43.656% -43.189%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  10 (10.00%) high mild
  9 (9.00%) high severe
  ```